### PR TITLE
Add TextFinder sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Real_doc
+
+This repository contains experimental projects. One of the projects is **TextFinder**, a simple web-based mobile application that uses the device camera to detect and search text in real time.
+
+## TextFinder
+
+TextFinder captures video from the camera, detects words using [Tesseract.js](https://github.com/naptha/tesseract.js), and draws red boxes around every word. A search box at the top allows filtering so only words containing the query are highlighted. For example, entering `C5` will highlight boxes that include `C5`.
+
+### Running
+
+Open `textfinder/index.html` in a modern browser (mobile or desktop). The browser will ask for camera permissions. Once granted, text boxes will appear over the video. Typing into the search box will filter the boxes by the provided term.
+
+### Naming idea
+
+A broad name for this application could be **"TextFinder"** or **"TextLens"**, which conveys text detection and search capabilities that might be used in practical scenarios or for patents.

--- a/textfinder/app.js
+++ b/textfinder/app.js
@@ -1,0 +1,48 @@
+const video = document.getElementById('video');
+const overlay = document.getElementById('overlay');
+const ctx = overlay.getContext('2d');
+const searchInput = document.getElementById('search');
+let currentText = [];
+
+async function setupCamera() {
+  const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+  video.srcObject = stream;
+  return new Promise(resolve => {
+    video.onloadedmetadata = () => {
+      overlay.width = video.videoWidth;
+      overlay.height = video.videoHeight;
+      resolve();
+    };
+  });
+}
+
+async function recognize() {
+  if (video.paused || video.ended) return requestAnimationFrame(recognize);
+  const worker = Tesseract.createWorker();
+  await worker.load();
+  await worker.loadLanguage('eng');
+  await worker.initialize('eng');
+  const { data } = await worker.recognize(video);
+  currentText = data.words;
+  await worker.terminate();
+  drawBoxes();
+  requestAnimationFrame(recognize);
+}
+
+function drawBoxes() {
+  ctx.clearRect(0, 0, overlay.width, overlay.height);
+  const query = searchInput.value.trim().toLowerCase();
+  currentText.forEach(word => {
+    const text = word.text.toLowerCase();
+    if (query === '' || text.includes(query)) {
+      const { x0, y0, x1, y1 } = word.bbox;
+      ctx.strokeStyle = 'red';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
+    }
+  });
+}
+
+searchInput.addEventListener('input', drawBoxes);
+
+setupCamera().then(recognize);

--- a/textfinder/index.html
+++ b/textfinder/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TextFinder</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
+</head>
+<body>
+    <div id="controls">
+        <input type="text" id="search" placeholder="Search text" />
+    </div>
+    <video id="video" autoplay playsinline></video>
+    <canvas id="overlay"></canvas>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/textfinder/style.css
+++ b/textfinder/style.css
@@ -1,0 +1,28 @@
+body {
+    margin: 0;
+    background: #000;
+    color: #fff;
+    font-family: Arial, sans-serif;
+}
+#controls {
+    position: absolute;
+    top: 10px;
+    width: 100%;
+    text-align: center;
+    z-index: 2;
+}
+#search {
+    padding: 8px;
+    font-size: 16px;
+    width: 200px;
+}
+video, canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+canvas {
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add a minimal web-based mobile OCR demo called **TextFinder**
- include HTML/CSS/JS assets and update README with instructions

## Testing
- `node -e "console.log('Node works')"`

------
https://chatgpt.com/codex/tasks/task_e_685b5d5054c0832aa66bea064be16dc6